### PR TITLE
Tweak for compatible layer

### DIFF
--- a/fluent-plugin-better-timestamp.gemspec
+++ b/fluent-plugin-better-timestamp.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", "~> 0.10.17"
+  gem.add_dependency "fluentd", [">= 0.10.17", "< 2"]
   gem.add_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
+  gem.add_development_dependency "test-unit", ">= 3.2.0"
 end

--- a/lib/fluent/plugin/out_better_timestamp.rb
+++ b/lib/fluent/plugin/out_better_timestamp.rb
@@ -4,6 +4,11 @@ module Fluent
   class BetterTimestampOutput < Output
     Fluent::Plugin.register_output('better_timestamp', self)
 
+    # Define `router` method of v0.12 to support v0.10 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     config_param :tag, :string
     config_param :msec_key, :string, :default => 'msec'
     config_param :timestamp_key, :string, :default => '@timestamp'
@@ -23,13 +28,12 @@ module Fluent
           @map[k] = v
         end
       }
-
     end
 
     def emit(tag, es, chain)
       es.each { |time, record|
         filter_record(tag, time, record)
-        Engine.emit(@tag, time, modify_record(time, record))
+        router.emit(@tag, time, modify_record(time, record))
       }
 
       chain.next

--- a/test/out_better_timestamp.rb
+++ b/test/out_better_timestamp.rb
@@ -10,7 +10,7 @@ class BetterTimestampOutputTest < Test::Unit::TestCase
     type better_timestamp
     tag foo.filtered
     msec_key msec
-    timestamp_key
+    timestamp_key @timestamp
   ]
 
   def create_driver(conf = CONFIG)
@@ -19,9 +19,8 @@ class BetterTimestampOutputTest < Test::Unit::TestCase
 
   def test_configure
     d = create_driver
-    map = d.instance.instance_variable_get(:@map)
 
-    #assert_equal 'msec', map['msec_key']
+    assert_equal 'msec', d.instance.msec_key
   end
 
   def test_remove_one_key
@@ -33,10 +32,14 @@ class BetterTimestampOutputTest < Test::Unit::TestCase
 
     mapped = {}
 
+    msec = 1
+    time = Time.now
+    time_str = Time.at(time.to_r, msec * 1000).strftime("%Y-%m-%dT%H:%M:%S.%L%z")
     d.run do
-      d.emit("msec" => '1', "k1" => 'v')
+      d.emit({"msec" => msec.to_s, "k1" => 'v'}, time.to_r)
     end
 
+    assert_equal time_str, d.records[0]['@timestamp']
     assert d.records[0]['@timestamp']
   end
 end

--- a/test/out_better_timestamp.rb
+++ b/test/out_better_timestamp.rb
@@ -33,13 +33,10 @@ class BetterTimestampOutputTest < Test::Unit::TestCase
     mapped = {}
 
     msec = 1
-    time = Time.now
-    time_str = Time.at(time.to_r, msec * 1000).strftime("%Y-%m-%dT%H:%M:%S.%L%z")
     d.run do
-      d.emit({"msec" => msec.to_s, "k1" => 'v'}, time.to_r)
+      d.emit({"msec" => msec, "k1" => 'v'})
     end
 
-    assert_equal time_str, d.records[0]['@timestamp']
     assert d.records[0]['@timestamp']
   end
 end


### PR DESCRIPTION
I think that this plugin should work with Fluentd v0.14 on compatible layer.
This plugin still locks Fluentd dependency and does not depends on test-unit for development.
And the biggest issue is using `Engine.emit`.
It causes raising exception at runtime because Fluentd v0.14 treats it as a bug.